### PR TITLE
Fix imports

### DIFF
--- a/packages/graphql-entity/index.d.ts
+++ b/packages/graphql-entity/index.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/runtime'

--- a/packages/graphql-entity/index.js
+++ b/packages/graphql-entity/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/runtime')

--- a/packages/graphql-entity/index.ts
+++ b/packages/graphql-entity/index.ts
@@ -1,1 +1,0 @@
-export * from './runtime'

--- a/packages/graphql-entity/package.json
+++ b/packages/graphql-entity/package.json
@@ -14,9 +14,13 @@
   },
   "files": [
     "/bin",
+    "/dist/*",
+    "/index.js",
+    "/index.d.ts",
     "/npm-shrinkwrap.json",
     "/oclif.manifest.json",
-    "/dist/*"
+    "/prelude.js",
+    "/prelude.d.ts"
   ],
   "scripts": {
     "test": "echo NO TESTS"

--- a/packages/graphql-entity/prelude.d.ts
+++ b/packages/graphql-entity/prelude.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/runtime/prelude'

--- a/packages/graphql-entity/prelude.js
+++ b/packages/graphql-entity/prelude.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/runtime/prelude')

--- a/packages/graphql-entity/prelude.ts
+++ b/packages/graphql-entity/prelude.ts
@@ -1,1 +1,0 @@
-export * from './runtime/prelude'

--- a/packages/graphql-entity/tsconfig.json
+++ b/packages/graphql-entity/tsconfig.json
@@ -2,15 +2,11 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "declaration": true,
     "importHelpers": true,
     "module": "commonjs",
     "outDir": "dist",
-    "rootDir": ".",
-    "baseUrl": ".",
-    "strict": true,
-    "target": "es2017"
+    "rootDir": "."
   },
-  "include": ["**/*"],
+  "include": ["cli/**/*", "compiler/**/*", "lib/**/*", "runtime/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -25,7 +25,13 @@ yarn run build
 # Login and publish packages locally
 (cd && npx npm-auth-to-token@1.0.0 -u user -p password -e user@example.com -r "$custom_registry_url")
 
+./scripts/exec.sh npm unpublish --force
 ./scripts/exec.sh npm publish
+
+# Remove the yarn workspace so that the install hits the registry
+rm package.json
+rm yarn.lock
+rm -rf node_modules
 
 # Create a test application
 mkdir test
@@ -42,12 +48,13 @@ cd test
 
 # Install dependencies from the local instance
 yarn install
+yarn add typescript
 
 # Run graphql-entity compilation
 yarn compile
 
 # Ensure build output works
-node ../node_modules/.bin/tsc -p tsconfig.json
+node ./node_modules/.bin/tsc -p tsconfig.json
 
 # Restore the original NPM and Yarn registry URLs
 npm set registry "$original_npm_registry_url"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2019",
     "module": "commonjs",
     "strict": true,
+    "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   }


### PR DESCRIPTION
Fixes `graphql-entity` and `graphql-entity/prelude` imports, which weren't working.

TypeScript doesn't pick up these issues due to the project reference in the basic project, and this stuck around even in the e2e tests, because yarn discovered the workspace root and re-used the node modules cache from the local build. That e2e test is updated in a way that catches this issue.