### PR TITLE
Fix relative import paths

### DIFF
--- a/packages/graphql-entity/compiler/__tests__/__snapshots__/compileIntegration.test.ts.snap
+++ b/packages/graphql-entity/compiler/__tests__/__snapshots__/compileIntegration.test.ts.snap
@@ -34,7 +34,7 @@ exports[`compiler basic regression test: file contents 2`] = `
 "// @gqle/generated
 import { Awaitable, Maybe, Resolvable } from \\"graphql-entity/prelude\\";
 import { createEntityServer as baseCreateEntityServer } from \\"graphql-entity\\";
-import { User as User } from \\"entity\\";
+import { User as User } from \\"./entity\\";
 
 
 /*

--- a/packages/graphql-entity/compiler/__tests__/compileInput.test.ts
+++ b/packages/graphql-entity/compiler/__tests__/compileInput.test.ts
@@ -125,7 +125,7 @@ describe('input types', () => {
     expect(file.writeImports()).toMatchInlineSnapshot(`
       "import { Awaitable, Maybe, Resolvable } from \\"graphql-entity/prelude\\";
       import { createEntityServer as baseCreateEntityServer } from \\"graphql-entity\\";
-      import { NeedsUserParameters } from \\"entity\\";
+      import { NeedsUserParameters } from \\"./entity\\";
       "
     `)
     expect(file.section('Root').write()).toMatchInlineSnapshot(`

--- a/packages/graphql-entity/compiler/writer/TSFile.ts
+++ b/packages/graphql-entity/compiler/writer/TSFile.ts
@@ -1,11 +1,11 @@
-import { dirname } from 'path'
-import { AbsolutePath } from '../../lib/path'
+import { dirname, sep as PLATFORM_SEP } from 'path'
+import { AbsolutePath, RelativePath } from '../../lib/path'
 import { unique } from '../utils/unique'
 import { capsToPascalCase } from '../utils/capsToPascalCase'
 import { withoutLastNewline } from '../../lib/string'
 
 export interface TSImport {
-  path: AbsolutePath | string
+  path: AbsolutePath | RelativePath | string
   name: string
   isDefault?: boolean
   alias?: string
@@ -155,6 +155,10 @@ export class TSFile {
 
   private importPath(path: AbsolutePath): string {
     let result = AbsolutePath.from(dirname(this.filepath.path)).pathTo(path).path
+
+    if (!result.startsWith('../')) {
+      result = `.${PLATFORM_SEP}${result}`
+    }
 
     if (result.endsWith('.ts')) {
       result = result.slice(0, -3)


### PR DESCRIPTION
This fixes an issue where relative imports from the current dir to sibling/descendant files would not have a leading dot, so the imports were treated as package imports instead of relative imports. E.g. `/` importing `/entity.ts` would import `entity` instead of `./entity`.

Today I learned that node's path normalization strips this because it resolves as many `.` and `..` as possible in path segments, so a leading `.` segment would be removed. `path.join` doesn't help because node normalizes the path after joining. So it can only be added manually.