### PR TITLE
Fix handling of input types in root extensions

### DIFF
--- a/packages/graphql-entity/compiler/__tests__/compileInput.test.ts
+++ b/packages/graphql-entity/compiler/__tests__/compileInput.test.ts
@@ -36,14 +36,9 @@ describe('input types', () => {
 
   test('references input types as arguments to queries', async () => {
     const entitySource = /* GraphQL */ `
-      input User {
-        name: String!
-        age: Int!
-      }
-
       extend type Query {
         needsNothing: Boolean!
-        needsUser(user: User!): Boolean!
+        needsUser(name: String!, age: Int!): Boolean!
       }
     `
 
@@ -57,7 +52,8 @@ describe('input types', () => {
        */
 
       export interface NeedsUserParameters {
-        user: User;
+        name: string;
+        age: number;
       }
 
       export interface RootExtensions {

--- a/packages/graphql-entity/compiler/print.ts
+++ b/packages/graphql-entity/compiler/print.ts
@@ -31,7 +31,7 @@ const findDocumentContainingType = ({
 const parametersInterface = ({ field }: { field: Field }): TSInterface => {
   return {
     name: `${capitalizeInitial(field.name)}Parameters`,
-    values: field.parameters.map(([name, type]) => [name, type.getName()]),
+    values: field.parameters.map(([name, type]) => [name, type.print()]),
   }
 }
 


### PR DESCRIPTION
Input types compiled to TS interfaces, specifically under the root extensions section in the root compilation, did not have their types formatted and were using the original type names.

Updated test and snapshots so this can't be missed in the future.