### PR TITLE
Fix issue where TS would not emit

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "4.0.2"
   },
   "scripts": {
-    "prebuild": "rm -rf packages/*/dist",
+    "prebuild": "rm -rf packages/*/dist packages/*/tsconfig.tsbuildinfo",
     "build": "tsc -b packages/* examples/*",
     "watch": "tsc -b packages/* examples/* --watch",
     "test": "jest --config scripts/jest/jest.config.js",

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -6,7 +6,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["**/*"],
   "exclude": ["node_modules", "dist"],
   "references": [{ "path": "../graphql-entity" }]
 }


### PR DESCRIPTION
What I'm finding is that unless the contents of the package change, the existence of a `.tsbuildinfo` file prevents a new compilation output. I'm sure this is an optimization for project references so that outputs aren't changed on incremental builds, but a full build needs to have a full output for CI and publishing.

The change to the `tsconfig` includes is just a cosmetic change, since it's not needed.